### PR TITLE
Make header sticky and scroll to top on logo click

### DIFF
--- a/src/components/Header/Header.tsx
+++ b/src/components/Header/Header.tsx
@@ -12,18 +12,22 @@ interface HeaderProps {
 }
 
 
-export const Header: React.FC<HeaderProps> = ({isDarkMode, handleTheme}) => {
+export const Header: React.FC<HeaderProps> = ({ isDarkMode, handleTheme }) => {
    return (
       <header className="header">
          <div className="header__wrapper">
-            <Link to="/" className="header__movies">
+            <Link
+               to="/"
+               className="header__movies"
+               onClick={() => window.scroll(0, 0)}
+            >
                <h1 className="header__title">Movies</h1>
 
                <img
-               className={isDarkMode ? "header__title-img" : ""}
-               src={camera}
-               width={30}
-               alt="Image of a camera"
+                  className={isDarkMode ? "header__title-img" : ""}
+                  src={camera}
+                  width={30}
+                  alt="Image of a camera"
                />
             </Link>
 


### PR DESCRIPTION
- Changed the header position to `sticky` so that it remains visible when scrolling.  

- Added logic to scroll to the top when the logo is clicked. 
